### PR TITLE
Send message to discord text channels

### DIFF
--- a/DiscordMessageSender.cs
+++ b/DiscordMessageSender.cs
@@ -1,0 +1,39 @@
+using Discord;
+using Discord.WebSocket;
+
+namespace SeafarersCowrieeater;
+
+public class DiscordMessageSender
+{
+    public async Task SendAsync(string token, string text, Stream imagesStream)
+    {
+        DiscordSocketClient client = new DiscordSocketClient();
+        await client.LoginAsync(TokenType.Bot, token);
+        await client.StartAsync();
+
+        var textChannels = GetTextChannels(client);
+
+        foreach (var textChannel in textChannels) 
+            await textChannel.SendFileAsync(imagesStream, text);
+    }
+
+    private IReadOnlyCollection<SocketTextChannel> GetTextChannels(DiscordSocketClient client)
+    {
+        List<SocketTextChannel> textChannels = [];
+        
+        foreach (var server in client.Guilds)
+        {
+            foreach (var textChannel in server.TextChannels)
+            {
+                var permissions = textChannel.GetPermissionOverwrite(client.CurrentUser);
+                
+                if (permissions is null) continue;
+                if (permissions.Value.SendMessages is not PermValue.Allow) continue;
+                
+                textChannels.Add(textChannel);
+            }
+        }
+
+        return textChannels;
+    }
+}

--- a/DiscordMessageSender.cs
+++ b/DiscordMessageSender.cs
@@ -17,6 +17,9 @@ public class DiscordMessageSender
             await textChannel.SendFileAsync(imagesStream, text);
     }
 
+    /// <summary>
+    ///     SendMessages, AttachFiles, EmbedLinks must be Allow.
+    /// </summary>
     private IReadOnlyCollection<SocketTextChannel> GetTextChannels(DiscordSocketClient client)
     {
         List<SocketTextChannel> textChannels = [];
@@ -29,6 +32,8 @@ public class DiscordMessageSender
                 
                 if (permissions is null) continue;
                 if (permissions.Value.SendMessages is not PermValue.Allow) continue;
+                if (permissions.Value.AttachFiles is not PermValue.Allow) continue;
+                if (permissions.Value.EmbedLinks is not PermValue.Allow) continue;
                 
                 textChannels.Add(textChannel);
             }

--- a/SeafarersCowrieeater.csproj
+++ b/SeafarersCowrieeater.csproj
@@ -7,4 +7,8 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Discord.Net" Version="3.17.1" />
+    </ItemGroup>
+
 </Project>

--- a/SeafarersCowrieeater.sln.DotSettings.user
+++ b/SeafarersCowrieeater.sln.DotSettings.user
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=cowrieeater/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
# 요약

봇 계정 자체에 권한을 부여한 텍스트 채널을 모두 찾아 전달받은 메시지를 전송합니다.

**요구 권한:**

- (채널 보기)
- 메세지 전송
- 파일 첨부
- 링크 첨부